### PR TITLE
Two new functions to align cards. 1- Align as line. 2-Align as square.

### DIFF
--- a/src/components/boardComponents/index.js
+++ b/src/components/boardComponents/index.js
@@ -102,13 +102,24 @@ export const itemMap = {
           "flipSelf",
           "tap",
           "stack",
+          "alignAsLine",
+          "alignAsSquare",
           "shuffle",
           "clone",
           "lock",
           "remove",
         ];
       } else {
-        return ["tap", "stack", "shuffle", "clone", "lock", "remove"];
+        return [
+          "tap",
+          "stack",
+          "alignAsLine",
+          "alignAsSquare",
+          "shuffle",
+          "clone",
+          "lock",
+          "remove",
+        ];
       }
     },
     availableActions: (item) => {
@@ -123,6 +134,8 @@ export const itemMap = {
           "rotate90",
           "rotate180",
           "stack",
+          "alignAsLine",
+          "alignAsSquare",
           "shuffle",
           "randomlyRotate30",
           "randomlyRotate45",
@@ -142,6 +155,8 @@ export const itemMap = {
           "rotate90",
           "rotate180",
           "stack",
+          "alignAsLine",
+          "alignAsSquare",
           "shuffle",
           "randomlyRotate30",
           "randomlyRotate45",

--- a/src/components/boardComponents/index.js
+++ b/src/components/boardComponents/index.js
@@ -102,8 +102,6 @@ export const itemMap = {
           "flipSelf",
           "tap",
           "stack",
-          "alignAsLine",
-          "alignAsSquare",
           "shuffle",
           "clone",
           "lock",

--- a/src/components/boardComponents/index.js
+++ b/src/components/boardComponents/index.js
@@ -32,7 +32,15 @@ export const itemMap = {
   rect: {
     component: Rect,
     defaultActions: ["lock", "remove"],
-    availableActions: ["stack", "alignAsLine", "alignAsSquare", "shuffle", "clone", "lock", "remove"],
+    availableActions: [
+      "stack",
+      "alignAsLine",
+      "alignAsSquare",
+      "shuffle",
+      "clone",
+      "lock",
+      "remove",
+    ],
     form: RectFormFields,
     label: i18n.t("Rectangle"),
     template: {},
@@ -40,7 +48,15 @@ export const itemMap = {
   cube: {
     component: Cube,
     defaultActions: ["clone", "lock", "remove"],
-    availableActions: ["stack", "alignAsLine", "alignAsSquare", "shuffle", "clone", "lock", "remove"],
+    availableActions: [
+      "stack",
+      "alignAsLine",
+      "alignAsSquare",
+      "shuffle",
+      "clone",
+      "lock",
+      "remove",
+    ],
     form: CubeFormFields,
     label: i18n.t("Cube"),
     template: {},
@@ -48,7 +64,15 @@ export const itemMap = {
   round: {
     component: Round,
     defaultActions: ["clone", "lock", "remove"],
-    availableActions: ["stack", "alignAsLine", "alignAsSquare", "shuffle", "clone", "lock", "remove"],
+    availableActions: [
+      "stack",
+      "alignAsLine",
+      "alignAsSquare",
+      "shuffle",
+      "clone",
+      "lock",
+      "remove",
+    ],
     form: RoundFormFields,
     label: i18n.t("Round"),
     template: {},
@@ -56,7 +80,15 @@ export const itemMap = {
   token: {
     component: Token,
     defaultActions: ["clone", "lock", "remove"],
-    availableActions: ["stack", "alignAsLine", "alignAsSquare", "shuffle", "clone", "lock", "remove"],
+    availableActions: [
+      "stack",
+      "alignAsLine",
+      "alignAsSquare",
+      "shuffle",
+      "clone",
+      "lock",
+      "remove",
+    ],
     form: TokenFormFields,
     label: i18n.t("Token"),
     template: {},
@@ -64,7 +96,15 @@ export const itemMap = {
   meeple: {
     component: Meeple,
     defaultActions: ["clone", "lock", "remove"],
-    availableActions: ["stack", "alignAsLine", "alignAsSquare", "shuffle", "clone", "lock", "remove"],
+    availableActions: [
+      "stack",
+      "alignAsLine",
+      "alignAsSquare",
+      "shuffle",
+      "clone",
+      "lock",
+      "remove",
+    ],
     form: MeepleFormFields,
     label: i18n.t("Meeple"),
     template: {},
@@ -72,7 +112,15 @@ export const itemMap = {
   pawn: {
     component: Pawn,
     defaultActions: ["clone", "lock", "remove"],
-    availableActions: ["stack", "alignAsLine", "alignAsSquare", "shuffle", "clone", "lock", "remove"],
+    availableActions: [
+      "stack",
+      "alignAsLine",
+      "alignAsSquare",
+      "shuffle",
+      "clone",
+      "lock",
+      "remove",
+    ],
     form: PawnFormFields,
     label: i18n.t("Pawn"),
     template: {},
@@ -80,7 +128,15 @@ export const itemMap = {
   jewel: {
     component: Jewel,
     defaultActions: ["clone", "lock", "remove"],
-    availableActions: ["stack", "alignAsLine", "alignAsSquare", "shuffle", "clone", "lock", "remove"],
+    availableActions: [
+      "stack",
+      "alignAsLine",
+      "alignAsSquare",
+      "shuffle",
+      "clone",
+      "lock",
+      "remove",
+    ],
     form: JewelFormFields,
     label: i18n.t("Jewel"),
     template: {},
@@ -108,14 +164,7 @@ export const itemMap = {
           "remove",
         ];
       } else {
-        return [
-          "tap",
-          "stack",
-          "shuffle",
-          "clone",
-          "lock",
-          "remove",
-        ];
+        return ["tap", "stack", "shuffle", "clone", "lock", "remove"];
       }
     },
     availableActions: (item) => {
@@ -180,7 +229,13 @@ export const itemMap = {
   dice: {
     component: Dice,
     defaultActions: ["clone", "lock", "remove"],
-    availableActions: ["clone", "lock", "remove", "alignAsLine", "alignAsSquare"],
+    availableActions: [
+      "clone",
+      "lock",
+      "remove",
+      "alignAsLine",
+      "alignAsSquare",
+    ],
     form: DiceFormFields,
     label: i18n.t("Dice"),
     template: {},
@@ -188,7 +243,14 @@ export const itemMap = {
   note: {
     component: Note,
     defaultActions: ["shuffle", "clone", "lock", "remove"],
-    availableActions: ["shuffle", "clone", "lock", "remove", "alignAsLine", "alignAsSquare"],
+    availableActions: [
+      "shuffle",
+      "clone",
+      "lock",
+      "remove",
+      "alignAsLine",
+      "alignAsSquare",
+    ],
     form: NoteFormFields,
     label: i18n.t("Note"),
     template: {},
@@ -196,7 +258,13 @@ export const itemMap = {
   zone: {
     component: Zone,
     defaultActions: ["clone", "lock", "remove"],
-    availableActions: ["clone", "lock", "remove", "alignAsLine", "alignAsSquare"],
+    availableActions: [
+      "clone",
+      "lock",
+      "remove",
+      "alignAsLine",
+      "alignAsSquare",
+    ],
     form: ZoneFormFields,
     label: i18n.t("Zone"),
     template: {},

--- a/src/components/boardComponents/index.js
+++ b/src/components/boardComponents/index.js
@@ -111,8 +111,6 @@ export const itemMap = {
         return [
           "tap",
           "stack",
-          "alignAsLine",
-          "alignAsSquare",
           "shuffle",
           "clone",
           "lock",

--- a/src/components/boardComponents/index.js
+++ b/src/components/boardComponents/index.js
@@ -32,7 +32,7 @@ export const itemMap = {
   rect: {
     component: Rect,
     defaultActions: ["lock", "remove"],
-    availableActions: ["stack", "shuffle", "clone", "lock", "remove"],
+    availableActions: ["stack", "alignAsLine", "alignAsSquare", "shuffle", "clone", "lock", "remove"],
     form: RectFormFields,
     label: i18n.t("Rectangle"),
     template: {},
@@ -40,7 +40,7 @@ export const itemMap = {
   cube: {
     component: Cube,
     defaultActions: ["clone", "lock", "remove"],
-    availableActions: ["stack", "shuffle", "clone", "lock", "remove"],
+    availableActions: ["stack", "alignAsLine", "alignAsSquare", "shuffle", "clone", "lock", "remove"],
     form: CubeFormFields,
     label: i18n.t("Cube"),
     template: {},
@@ -48,7 +48,7 @@ export const itemMap = {
   round: {
     component: Round,
     defaultActions: ["clone", "lock", "remove"],
-    availableActions: ["stack", "shuffle", "clone", "lock", "remove"],
+    availableActions: ["stack", "alignAsLine", "alignAsSquare", "shuffle", "clone", "lock", "remove"],
     form: RoundFormFields,
     label: i18n.t("Round"),
     template: {},
@@ -56,7 +56,7 @@ export const itemMap = {
   token: {
     component: Token,
     defaultActions: ["clone", "lock", "remove"],
-    availableActions: ["stack", "shuffle", "clone", "lock", "remove"],
+    availableActions: ["stack", "alignAsLine", "alignAsSquare", "shuffle", "clone", "lock", "remove"],
     form: TokenFormFields,
     label: i18n.t("Token"),
     template: {},
@@ -64,7 +64,7 @@ export const itemMap = {
   meeple: {
     component: Meeple,
     defaultActions: ["clone", "lock", "remove"],
-    availableActions: ["stack", "shuffle", "clone", "lock", "remove"],
+    availableActions: ["stack", "alignAsLine", "alignAsSquare", "shuffle", "clone", "lock", "remove"],
     form: MeepleFormFields,
     label: i18n.t("Meeple"),
     template: {},
@@ -72,7 +72,7 @@ export const itemMap = {
   pawn: {
     component: Pawn,
     defaultActions: ["clone", "lock", "remove"],
-    availableActions: ["stack", "shuffle", "clone", "lock", "remove"],
+    availableActions: ["stack", "alignAsLine", "alignAsSquare", "shuffle", "clone", "lock", "remove"],
     form: PawnFormFields,
     label: i18n.t("Pawn"),
     template: {},
@@ -80,7 +80,7 @@ export const itemMap = {
   jewel: {
     component: Jewel,
     defaultActions: ["clone", "lock", "remove"],
-    availableActions: ["stack", "shuffle", "clone", "lock", "remove"],
+    availableActions: ["stack", "alignAsLine", "alignAsSquare", "shuffle", "clone", "lock", "remove"],
     form: JewelFormFields,
     label: i18n.t("Jewel"),
     template: {},
@@ -180,7 +180,7 @@ export const itemMap = {
   dice: {
     component: Dice,
     defaultActions: ["clone", "lock", "remove"],
-    availableActions: ["clone", "lock", "remove"],
+    availableActions: ["clone", "lock", "remove", "alignAsLine", "alignAsSquare"],
     form: DiceFormFields,
     label: i18n.t("Dice"),
     template: {},
@@ -188,7 +188,7 @@ export const itemMap = {
   note: {
     component: Note,
     defaultActions: ["shuffle", "clone", "lock", "remove"],
-    availableActions: ["shuffle", "clone", "lock", "remove"],
+    availableActions: ["shuffle", "clone", "lock", "remove", "alignAsLine", "alignAsSquare"],
     form: NoteFormFields,
     label: i18n.t("Note"),
     template: {},
@@ -196,7 +196,7 @@ export const itemMap = {
   zone: {
     component: Zone,
     defaultActions: ["clone", "lock", "remove"],
-    availableActions: ["clone", "lock", "remove"],
+    availableActions: ["clone", "lock", "remove", "alignAsLine", "alignAsSquare"],
     form: ZoneFormFields,
     label: i18n.t("Zone"),
     template: {},

--- a/src/components/boardComponents/useItemActions.js
+++ b/src/components/boardComponents/useItemActions.js
@@ -186,10 +186,6 @@ export const useItemActions = () => {
         )
       );
 
-      // const [newX, newY] = [
-      //   (minMax.min.x + minMax.max.x) / 2,
-      //   (minMax.min.y + minMax.max.y) / 2,
-      // ];
       const [newX, newY] = [minMax.min.x, minMax.max.y];
       let index = -1;
       let currentColumn = -1;

--- a/src/components/boardComponents/useItemActions.js
+++ b/src/components/boardComponents/useItemActions.js
@@ -155,7 +155,7 @@ export const useItemActions = () => {
         return {
           ...item,
           x: newX + index * clientWidth,
-          y: newY - index,
+          y: newY,
         };
       });
     },

--- a/src/components/boardComponents/useItemActions.js
+++ b/src/components/boardComponents/useItemActions.js
@@ -18,6 +18,8 @@ import { shuffle as shuffleArray, randInt } from "../../utils";
 
 import deleteIcon from "../../images/delete.svg";
 import stackIcon from "../../images/stack.svg";
+import alignAsLineIcon from "../../images/alignAsLine.svg";
+import alignAsSquareIcon from "../../images/alignAsSquare.svg";
 import duplicateIcon from "../../images/duplicate.svg";
 import seeIcon from "../../images/see.svg";
 import flipIcon from "../../images/flip.svg";
@@ -119,6 +121,92 @@ export const useItemActions = () => {
           ...item,
           x: newX - clientWidth / 2 + index,
           y: newY - clientHeight / 2 - index,
+        };
+      });
+    },
+    [getSelectedItemList, batchUpdateItems, selectedItems]
+  );
+
+  // Align selection to a line
+  const alignAsLine = useRecoilCallback(
+    ({ snapshot }) => async () => {
+      const selectedItemList = await getSelectedItemList(snapshot);
+
+      // Compute
+      const minMax = { min: {}, max: {} };
+      minMax.min.x = Math.min(...selectedItemList.map(({ x }) => x));
+      minMax.min.y = Math.min(...selectedItemList.map(({ y }) => y));
+      minMax.max.x = Math.max(
+        ...selectedItemList.map(
+          ({ x, id }) => x + document.getElementById(id).clientWidth
+        )
+      );
+      minMax.max.y = Math.max(
+        ...selectedItemList.map(
+          ({ y, id }) => y //+ document.getElementById(id).clientHeight
+        )
+      );
+
+      const [newX, newY] = [minMax.min.x, minMax.max.y];
+      let index = -1;
+      batchUpdateItems(selectedItems, (item) => {
+        index += 1;
+        const { clientWidth, clientHeight } = document.getElementById(item.id);
+        return {
+          ...item,
+          x: newX + index * clientWidth,
+          y: newY - index,
+        };
+      });
+    },
+    [getSelectedItemList, batchUpdateItems, selectedItems]
+  );
+
+  // Align selection to an array
+  const alignAsSquare = useRecoilCallback(
+    ({ snapshot }) => async () => {
+      const selectedItemList = await getSelectedItemList(snapshot);
+
+      // Count number of elements
+      const numberOfElements = selectedItemList.length;
+      const numberOfColumns = Math.ceil(Math.sqrt(numberOfElements));
+
+      // Compute
+      const minMax = { min: {}, max: {} };
+      minMax.min.x = Math.min(...selectedItemList.map(({ x }) => x));
+      minMax.min.y = Math.min(...selectedItemList.map(({ y }) => y));
+      minMax.max.x = Math.max(
+        ...selectedItemList.map(
+          ({ x, id }) => x + document.getElementById(id).clientWidth
+        )
+      );
+      minMax.max.y = Math.max(
+        ...selectedItemList.map(
+          ({ y, id }) => y //+ document.getElementById(id).clientHeight
+        )
+      );
+
+      // const [newX, newY] = [
+      //   (minMax.min.x + minMax.max.x) / 2,
+      //   (minMax.min.y + minMax.max.y) / 2,
+      // ];
+      const [newX, newY] = [minMax.min.x, minMax.max.y];
+      let index = -1;
+      let currentColumn = -1;
+      let currentRow = 0;
+      batchUpdateItems(selectedItems, (item) => {
+        index += 1;
+        currentColumn += 1;
+        if (currentColumn + 1 > numberOfColumns) {
+          currentColumn = 0;
+          currentRow += 1;
+        }
+
+        const { clientWidth, clientHeight } = document.getElementById(item.id);
+        return {
+          ...item,
+          x: newX + currentColumn * clientWidth,
+          y: newY - currentRow * clientHeight,
         };
       });
     },
@@ -298,6 +386,20 @@ export const useItemActions = () => {
         shortcut: "",
         multiple: true,
         icon: stackIcon,
+      },
+      alignAsLine: {
+        action: alignAsLine,
+        label: t("Align as line"),
+        shortcut: "",
+        multiple: true,
+        icon: alignAsLineIcon,
+      },
+      alignAsSquare: {
+        action: alignAsSquare,
+        label: t("Align as square"),
+        shortcut: "",
+        multiple: true,
+        icon: alignAsSquareIcon,
       },
       shuffle: {
         action: shuffleSelectedItems,

--- a/src/components/boardComponents/useItemActions.js
+++ b/src/components/boardComponents/useItemActions.js
@@ -202,7 +202,7 @@ export const useItemActions = () => {
         return {
           ...item,
           x: newX + currentColumn * clientWidth,
-          y: newY - currentRow * clientHeight,
+          y: newY + currentRow * clientHeight,
         };
       });
     },

--- a/src/components/boardComponents/useItemActions.js
+++ b/src/components/boardComponents/useItemActions.js
@@ -143,7 +143,7 @@ export const useItemActions = () => {
       );
       minMax.max.y = Math.max(
         ...selectedItemList.map(
-          ({ y, id }) => y //+ document.getElementById(id).clientHeight
+          ({ y, id }) => y
         )
       );
 

--- a/src/components/boardComponents/useItemActions.js
+++ b/src/components/boardComponents/useItemActions.js
@@ -182,7 +182,7 @@ export const useItemActions = () => {
       );
       minMax.max.y = Math.max(
         ...selectedItemList.map(
-          ({ y, id }) => y //+ document.getElementById(id).clientHeight
+          ({ y, id }) => y
         )
       );
 

--- a/src/components/boardComponents/useItemActions.js
+++ b/src/components/boardComponents/useItemActions.js
@@ -141,11 +141,7 @@ export const useItemActions = () => {
           ({ x, id }) => x + document.getElementById(id).clientWidth
         )
       );
-      minMax.max.y = Math.max(
-        ...selectedItemList.map(
-          ({ y, id }) => y
-        )
-      );
+      minMax.max.y = Math.max(...selectedItemList.map(({ y, id }) => y));
 
       const [newX, newY] = [minMax.min.x, minMax.max.y];
       let index = -1;
@@ -180,11 +176,7 @@ export const useItemActions = () => {
           ({ x, id }) => x + document.getElementById(id).clientWidth
         )
       );
-      minMax.max.y = Math.max(
-        ...selectedItemList.map(
-          ({ y, id }) => y
-        )
-      );
+      minMax.max.y = Math.max(...selectedItemList.map(({ y, id }) => y));
 
       const [newX, newY] = [minMax.min.x, minMax.max.y];
       let index = -1;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -19,6 +19,8 @@
   "Cancel": "Cancel",
   "Shuffle": "Shuffle",
   "Stack": "Stack",
+  "Align as line": "Align as line",
+  "Align as square": "Align as square",
   "Hide": "Hide",
   "Reveal": "Reveal",
   "Remove all": "Remove all",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -19,6 +19,8 @@
   "Cancel": "Annuler",
   "Shuffle": "Mélanger",
   "Stack": "Empiler",
+  "Align as line": "Aligner en ligne",
+  "Align as square": "Arranger en carré",
   "Hide": "Retourner",
   "Reveal": "Révéler",
   "Remove all": "Tout supprimer",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -19,7 +19,7 @@
   "Cancel": "Annuler",
   "Shuffle": "Mélanger",
   "Stack": "Empiler",
-  "Align as line": "Aligner en ligne",
+  "Align as line": "Aligner",
   "Align as square": "Arranger en carré",
   "Hide": "Retourner",
   "Reveal": "Révéler",

--- a/src/images/alignAsLine.svg
+++ b/src/images/alignAsLine.svg
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 82.000008 74.000038"
+   id="svg10"
+   sodipodi:docname="alignAsLine.svg"
+   width="82.000008"
+   height="74.000038"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15, custom)">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     id="namedview12"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="5.3400704"
+     inkscape:cx="3.1193018"
+     inkscape:cy="68.910429"
+     inkscape:window-x="2391"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g4"
+     inkscape:pagecheckerboard="true"
+     inkscape:document-rotation="0"
+     inkscape:snap-grids="true"
+     inkscape:snap-center="false" />
+  <g
+     transform="translate(-8.999998,-965.36216)"
+     id="g4"
+     style="fill:#ffffff">
+    <rect
+       style="fill:#ffffff;stroke-width:0.747344"
+       id="rect10"
+       width="18.988312"
+       height="34.831001"
+       x="10.155707"
+       y="984.22089" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.747344"
+       id="rect10-8"
+       width="18.988312"
+       height="34.831001"
+       x="30.657436"
+       y="984.22089"
+       inkscape:transform-center-x="20.263647"
+       inkscape:transform-center-y="-14.512929" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.747344"
+       id="rect10-8-5"
+       width="18.988312"
+       height="34.831001"
+       x="51.159168"
+       y="984.22089"
+       inkscape:transform-center-x="20.263645"
+       inkscape:transform-center-y="-14.512929" />
+    <ellipse
+       style="fill:#ffffff;stroke-width:1.1556"
+       id="path52"
+       cx="74.508331"
+       cy="1001.6364"
+       rx="2.5482163"
+       ry="2.3247285" />
+    <ellipse
+       style="fill:#ffffff;stroke-width:1.1556"
+       id="path52-8"
+       cx="81.678452"
+       cy="1001.6364"
+       rx="2.5482163"
+       ry="2.3247285" />
+    <ellipse
+       style="fill:#ffffff;stroke-width:1.1556"
+       id="path52-3"
+       cx="88.219986"
+       cy="1001.6364"
+       rx="2.5482163"
+       ry="2.3247285" />
+  </g>
+</svg>

--- a/src/images/alignAsSquare.svg
+++ b/src/images/alignAsSquare.svg
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 82.000008 74.000038"
+   id="svg10"
+   sodipodi:docname="alignAsSquare.svg"
+   width="82.000008"
+   height="74.000038"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15, custom)">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     id="namedview12"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="2.6700352"
+     inkscape:cx="5.8311622"
+     inkscape:cy="73.010552"
+     inkscape:window-x="2391"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g4"
+     inkscape:pagecheckerboard="true"
+     inkscape:document-rotation="0"
+     inkscape:snap-grids="true"
+     inkscape:snap-center="false" />
+  <g
+     transform="translate(-8.999998,-965.36216)"
+     id="g4"
+     style="fill:#ffffff">
+    <rect
+       style="fill:#ffffff;stroke-width:0.568895"
+       id="rect10"
+       width="17.173176"
+       height="22.316481"
+       x="12.060472"
+       y="1015.4618" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.568895"
+       id="rect10-8"
+       width="17.173176"
+       height="22.316481"
+       x="30.946436"
+       y="1015.4618"
+       inkscape:transform-center-x="18.3266"
+       inkscape:transform-center-y="-9.2985368" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.568895"
+       id="rect10-8-5"
+       width="17.173176"
+       height="22.316481"
+       x="49.832401"
+       y="1015.4618"
+       inkscape:transform-center-x="18.326595"
+       inkscape:transform-center-y="-9.2985368" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.568895"
+       id="rect10-8-5-9"
+       width="17.173176"
+       height="22.316481"
+       x="68.718361"
+       y="1015.4618"
+       inkscape:transform-center-x="18.326594"
+       inkscape:transform-center-y="-9.2985368" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.568895"
+       id="rect10-1"
+       width="17.173176"
+       height="22.316481"
+       x="12.060469"
+       y="991.29767" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.568895"
+       id="rect10-8-2"
+       width="17.173176"
+       height="22.316481"
+       x="30.946432"
+       y="991.29767"
+       inkscape:transform-center-x="18.3266"
+       inkscape:transform-center-y="-9.2985595" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.568895"
+       id="rect10-8-5-6"
+       width="17.173176"
+       height="22.316481"
+       x="49.832401"
+       y="991.29767"
+       inkscape:transform-center-x="18.326595"
+       inkscape:transform-center-y="-9.2985595" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.568895"
+       id="rect10-8-5-9-3"
+       width="17.173176"
+       height="22.316481"
+       x="68.718361"
+       y="991.29767"
+       inkscape:transform-center-x="18.326594"
+       inkscape:transform-center-y="-9.2985595" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.568895"
+       id="rect10-1-2"
+       width="17.173176"
+       height="22.316481"
+       x="12.060469"
+       y="967.13354" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.568895"
+       id="rect10-8-2-4"
+       width="17.173176"
+       height="22.316481"
+       x="30.94643"
+       y="967.13354"
+       inkscape:transform-center-x="18.3266"
+       inkscape:transform-center-y="-9.2985259" />
+    <path
+       style="fill:#ffffff;stroke-width:0.524756"
+       id="path153"
+       sodipodi:type="arc"
+       sodipodi:cx="59.541576"
+       sodipodi:cy="979.29883"
+       sodipodi:rx="3.9152231"
+       sodipodi:ry="2.7145131"
+       sodipodi:start="0"
+       sodipodi:end="6.283012"
+       sodipodi:arc-type="slice"
+       d="m 63.4568,979.29883 a 3.9152231,2.7145131 0 0 1 -3.915054,2.71451 3.9152231,2.7145131 0 0 1 -3.915393,-2.71428 3.9152231,2.7145131 0 0 1 3.914714,-2.71474 3.9152231,2.7145131 0 0 1 3.915732,2.71404 l -3.915223,4.7e-4 z" />
+    <path
+       style="fill:#ffffff;stroke-width:0.524756"
+       id="path153-2"
+       sodipodi:type="arc"
+       sodipodi:cx="70.347473"
+       sodipodi:cy="979.29883"
+       sodipodi:rx="3.9152231"
+       sodipodi:ry="2.7145131"
+       sodipodi:start="0"
+       sodipodi:end="6.283012"
+       sodipodi:arc-type="slice"
+       d="m 74.262696,979.29883 a 3.9152231,2.7145131 0 0 1 -3.915053,2.71451 3.9152231,2.7145131 0 0 1 -3.915393,-2.71428 3.9152231,2.7145131 0 0 1 3.914714,-2.71474 3.9152231,2.7145131 0 0 1 3.915732,2.71404 l -3.915223,4.7e-4 z" />
+    <path
+       style="fill:#ffffff;stroke-width:0.524756"
+       id="path153-2-5"
+       sodipodi:type="arc"
+       sodipodi:cx="81.153366"
+       sodipodi:cy="979.43927"
+       sodipodi:rx="3.9152231"
+       sodipodi:ry="2.7145131"
+       sodipodi:start="0"
+       sodipodi:end="6.283012"
+       sodipodi:arc-type="slice"
+       d="m 85.068589,979.43927 a 3.9152231,2.7145131 0 0 1 -3.915053,2.71451 3.9152231,2.7145131 0 0 1 -3.915393,-2.71427 3.9152231,2.7145131 0 0 1 3.914714,-2.71475 3.9152231,2.7145131 0 0 1 3.915732,2.71404 l -3.915223,4.7e-4 z" />
+  </g>
+</svg>


### PR DESCRIPTION
Two new functions to align only cards :
-> Functions are based on `align` function with new icons.
-> Activated only for `Image` items.

 1. `alignAsLine`: to align as a line.
- Position of origin : the card position at most left down.
- Align's direction : from left to right.
2. `alignAsSquare`: to align as a square.
- Position of origin : the card position at most left down.
- Align's direction : from left to right. At end of a row, new align begin at the top row.
- Square's dimension depend of the number of items, to best fill the square.