### PR TITLE
Adds basic game search on the homepage (substring naive scan)

### DIFF
--- a/cypress/integration/homepage.spec.js
+++ b/cypress/integration/homepage.spec.js
@@ -1,0 +1,37 @@
+describe("Homepage", () => {
+  beforeEach(() => {
+    cy.viewport(1000, 600);
+    cy.visit("/games");
+  });
+
+  it("should show all available games by default", () => {
+    cy.contains("0 Test game").should("be.visible");
+    cy.contains("1 Performance game to test strange things and other").should(
+      "be.visible"
+    );
+  });
+
+  it("should show both default games if searching for 'test' string", () => {
+    cy.get('input[name="game-search"').type('test');
+    cy.contains("0 Test game").should("be.visible");
+    cy.contains("1 Performance game to test strange things and other").should(
+      "be.visible"
+    );
+  });
+
+  it("should show only game 1 if searching for 'Performance' string", () => {
+    cy.get('input[name="game-search"').type('Performance');
+    cy.contains("0 Test game").should("not.exist");
+    cy.contains("1 Performance game to test strange things and other").should(
+      "be.visible"
+    );
+  });
+
+  it("should not show any game for 'thisisafancystring' string", () => {
+    cy.get('input[name="game-search"').type('thisisafancystring');
+    cy.contains("0 Test game").should("not.exist");
+    cy.contains("1 Performance game to test strange things and other").should(
+      "not.exist"
+    );
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8140,6 +8140,11 @@
         "typescript": "^3.8.3"
       }
     },
+    "diacritic": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/diacritic/-/diacritic-0.0.2.tgz",
+      "integrity": "sha1-/CqIe1pbwKCoVPthTHwvIJBh7gQ="
+    },
     "diff-sequences": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "client2client.io": "^1.3.4",
     "color2k": "^1.0.0-rc.5",
     "dayjs": "^1.10.4",
+    "diacritic": "0.0.2",
     "final-form": "^4.20.0",
     "i18next": "^19.4.5",
     "i18next-browser-languagedetector": "^4.3.1",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -224,5 +224,7 @@
   "User details": "User details",
   "Username": "Username",
   "All players": "All players",
-  "Invite more player": "Invite more player"
+  "Invite more player": "Invite more player",
+  "Search for a game": "Search for a game",
+  "games-available": "{{ nbOfGames }} games available"
 }

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -222,5 +222,7 @@
   "User details": "Informations utilisateur",
   "Username": "Nom",
   "All players": "Tous les joueurs",
-  "Invite more player": "Invitez vos ami·e·s"
+  "Invite more player": "Invitez vos ami·e·s",
+  "Search for a game": "Cherchez un jeu",
+  "games-available": "{{ nbOfGames }} jeux disponibles"
 }

--- a/src/views/GameStudio.jsx
+++ b/src/views/GameStudio.jsx
@@ -6,7 +6,7 @@ import styled from "styled-components";
 import { getGames } from "../utils/api";
 import useAuth from "../hooks/useAuth";
 
-import StyledGameList from "./StyledGameList";
+import { StyledGameList } from "./StyledGameList";
 import NewGameItem from "./NewGameItem";
 import GameListItem from "./GameListItem";
 

--- a/src/views/StyledGameList.jsx
+++ b/src/views/StyledGameList.jsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-const StyledGameList = styled.ul`
+export const StyledGameList = styled.ul`
   list-style: none;
   margin: 0;
   padding: 0 5%;
@@ -18,4 +18,29 @@ const StyledGameList = styled.ul`
   }
 `;
 
-export default StyledGameList;
+export const StyledGameFilters = styled.ul`
+  list-style: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+
+  li {
+    flex: auto;
+    max-width: 30rem;
+    margin: 0 1rem;
+  }
+
+  input:not([type="checkbox"]):not([type="radio"]):not([type="submit"]):not([type="color"]):not([type="button"]):not([type="reset"]) {
+    background-color: #1c1c1c;
+    color: var(--font-color2);
+
+    &::placeholder {
+      color: var(--font-color2);
+    }
+  }
+`;
+
+export const StyledGameResultNumber = styled.p`
+  text-align: center;
+`;


### PR DESCRIPTION
Current visual state:
<img width="1390" alt="Screen Shot 2021-04-04 at 19 56 38" src="https://user-images.githubusercontent.com/2834704/113518711-f2185c00-957f-11eb-8df9-2c70f7043860.png">


Remaining work on this PR:
- [x] Improve the design,
- [x] Debug current search issue ("Perf" shows the performance test, but not "Perfo"),
- [x] Discuss the code structure (some bits from the custom box filtering could be reused here?),
- [x] Add a message if no game found with the search term,
- [x] Debug current `500` error call on each search key stroke,
- [x] Make text translatable, and add translations,
- [x] Add cypress tests.

<img width="1408" alt="Screen Shot 2021-04-02 at 19 51 29" src="https://user-images.githubusercontent.com/2834704/113445014-ee080500-93ec-11eb-8f56-7bff0d8c7af0.png">


Related to #292. 