### PR TITLE
Unifies Range Slider in homepage and game edition

### DIFF
--- a/cypress/integration/studio.spec.js
+++ b/cypress/integration/studio.spec.js
@@ -194,7 +194,7 @@ describe("Studio", () => {
 
       cy.get(".item").parent().should("have.css", "z-index", "3");
 
-      cy.get(".rc-slider-mark-text").contains("-1").click();
+      cy.get(".slider-layer .rc-slider-mark-text").contains("-1").click();
 
       cy.get(".item").parent().should("have.css", "z-index", "2");
     });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,7 +13,6 @@ import { nanoid } from "nanoid";
 import { ToastContainer } from "react-toastify";
 
 import "react-toastify/dist/ReactToastify.css";
-import "rc-slider/assets/index.css";
 import "./react-confirm-alert.css";
 
 import Home from "./views/Home";

--- a/src/components/BoardConfig.jsx
+++ b/src/components/BoardConfig.jsx
@@ -11,7 +11,6 @@ import AutoSave from "../ui/formUtils/AutoSave";
 import Hint from "../ui/formUtils/Hint";
 import Label from "../ui/formUtils/Label";
 import SliderRange from "../ui/SliderRange";
-import { Range } from "rc-slider";
 
 const BoardConfigForm = styled.div`
   display: flex;

--- a/src/components/BoardConfig.jsx
+++ b/src/components/BoardConfig.jsx
@@ -1,16 +1,17 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
-
+import { nanoid } from "nanoid";
 import { Form, Field } from "react-final-form";
-import AutoSave from "../ui/formUtils/AutoSave";
-import Label from "../ui/formUtils/Label";
+
 import useBoardConfig from "./useBoardConfig";
 import { ImageField } from "./mediaLibrary";
-import Hint from "../ui/formUtils/Hint";
 
+import AutoSave from "../ui/formUtils/AutoSave";
+import Hint from "../ui/formUtils/Hint";
+import Label from "../ui/formUtils/Label";
+import SliderRange from "../ui/SliderRange";
 import { Range } from "rc-slider";
-import { nanoid } from "nanoid";
 
 const BoardConfigForm = styled.div`
   display: flex;
@@ -74,26 +75,13 @@ const BoardConfig = () => {
             >
               {({ input: { onChange, value } }) => {
                 return (
-                  <Range
+                  <SliderRange
                     defaultValue={[2, 4]}
                     value={value}
                     min={1}
                     max={9}
                     step={1}
-                    marks={{
-                      1: "1",
-                      2: "2",
-                      3: "3",
-                      4: "4",
-                      5: "5",
-                      6: "6",
-                      7: "7",
-                      8: "8",
-                      9: "9+",
-                    }}
-                    style={{ width: "20em" }}
                     onChange={onChange}
-                    dots
                   />
                 );
               }}
@@ -111,20 +99,12 @@ const BoardConfig = () => {
             >
               {({ input: { onChange, value } }) => {
                 return (
-                  <Range
-                    defaultValue={[2, 4]}
+                  <SliderRange
+                    defaultValue={[15, 90]}
                     value={value}
                     min={15}
                     max={90}
-                    step={null}
-                    marks={{
-                      15: "15",
-                      30: "30",
-                      45: "45",
-                      60: "60",
-                      90: "90+",
-                    }}
-                    style={{ width: "20em" }}
+                    step={15}
                     onChange={onChange}
                   />
                 );

--- a/src/components/boardComponents/ItemFormFactory.jsx
+++ b/src/components/boardComponents/ItemFormFactory.jsx
@@ -4,7 +4,6 @@ import { useTranslation } from "react-i18next";
 
 import { useRecoilValue } from "recoil";
 
-import Slider from "rc-slider";
 import { Form, Field } from "react-final-form";
 
 import AutoSave from "../../ui/formUtils/AutoSave";
@@ -14,6 +13,7 @@ import { useItems } from "../Board/Items";
 
 import Label from "../../ui/formUtils/Label";
 import Hint from "../../ui/formUtils/Hint";
+import Slider from "../../ui/Slider";
 
 import ActionsField from "./ActionsField";
 
@@ -104,6 +104,7 @@ const ItemFormFactory = () => {
                     step={5}
                     included={false}
                     marks={{
+                      "-180": -180,
                       "-90": -90,
                       "-45": -45,
                       "-30": -30,
@@ -111,8 +112,10 @@ const ItemFormFactory = () => {
                       30: 30,
                       45: 45,
                       90: 90,
+                      180: 180,
                     }}
                     onChange={onChange}
+                    className={"slider-rotation"}
                   />
                 );
               }}
@@ -140,6 +143,7 @@ const ItemFormFactory = () => {
                       "3": 3,
                     }}
                     onChange={onChange}
+                    className={"slider-layer"}
                   />
                 );
               }}

--- a/src/ui/Slider.jsx
+++ b/src/ui/Slider.jsx
@@ -1,35 +1,64 @@
 import React from "react";
 import RCSlider from "rc-slider";
+import styled from "styled-components";
 
 import "rc-slider/assets/index.css";
 
+const StyledSlider = styled.div`
+  margin: 0 0.5em;
+
+  .rc-slider-mark-text {
+    font-size: 1rem;
+  }
+
+  .rc-slider-mark-text-active {
+    color: white;
+    font-weight: bold;
+    font-size: 1.2rem;
+    border-radius: 1rem;
+    padding: 2px 7px 0px 7px;
+    background-color: var(--color-primary);
+
+    &:before {
+      content: "";
+      position: absolute;
+      margin-top: -10px; // adjust position, arrow has a height of 30px.
+      left: 5px;
+      border: solid 5px transparent;
+      border-bottom-color: var(--color-primary);
+      z-index: 1;
+    }
+  }
+`;
+
 export const sliderStyling = {
-  trackStyle: [
-    {
-      backgroundColor: "var(--color-primary)",
-      height: "5px",
-    },
-  ],
-  railStyle: {
-    backgroundColor: "var(--font-color2)",
-  },
   handleStyle: [
     {
       backgroundColor: "white",
       borderColor: "white",
     },
-    {
-      backgroundColor: "white",
-      borderColor: "white",
-    },
   ],
+  railStyle: {
+    backgroundColor: "var(--color-primary)",
+  },
+  dotStyle: {
+    backgroundColor: "var(--font-color2)",
+    border: "var(--font-color2)",
+    width: "6px",
+    height: "6px",
+    bottom: "-1px",
+  },
 };
 
 // Please check https://github.com/react-component/slider#user-content-common-api
 // for all available props.
 // RCSlider refers to the Slider component of the rc-react library.
 const Slider = (props) => {
-  return <RCSlider {...props} {...sliderStyling} style={{ width: "20em" }} />;
+  return (
+    <StyledSlider className={props.className}>
+      <RCSlider {...props} {...sliderStyling} />
+    </StyledSlider>
+  );
 };
 
 export default Slider;

--- a/src/ui/SliderRange.jsx
+++ b/src/ui/SliderRange.jsx
@@ -19,8 +19,15 @@ const StyledSliderRange = styled.div`
 
 // Please check https://github.com/react-component/slider#user-content-common-api
 // for all available props.
-const SliderRange = ({ defaultValue: [min, max], ...props }) => {
-  const [minMaxValues, setMinMaxValues] = React.useState([min, max]);
+const SliderRange = ({
+  defaultValue: [defaultMin, defaultMax],
+  plusSignMode = true,
+  ...props
+}) => {
+  const [minMaxValues, setMinMaxValues] = React.useState([
+    props.value.length ? props.value[0] : defaultMin,
+    props.value.length ? props.value[1] : defaultMax,
+  ]);
 
   const onChangeCustom = function (values) {
     setMinMaxValues(values);
@@ -33,14 +40,15 @@ const SliderRange = ({ defaultValue: [min, max], ...props }) => {
       <Range
         {...props}
         {...sliderStyling}
-        min={min}
-        max={max}
+        value={props.value.length ? props.value : [defaultMin, defaultMax]}
         style={{
           width: "20em",
         }}
         onChange={onChangeCustom}
       />
-      <span>{`${minMaxValues[1]}`}</span>
+      <span>{`${minMaxValues[1]}${
+        plusSignMode && minMaxValues[1] == props.max ? "+" : ""
+      }`}</span>
     </StyledSliderRange>
   );
 };

--- a/src/ui/SliderRange.jsx
+++ b/src/ui/SliderRange.jsx
@@ -4,8 +4,6 @@ import styled from "styled-components";
 
 import "rc-slider/assets/index.css";
 
-import { sliderStyling } from "./Slider";
-
 const StyledSliderRange = styled.div`
   display: flex;
   align-items: center;
@@ -16,6 +14,28 @@ const StyledSliderRange = styled.div`
     color: var(--font-color2);
   }
 `;
+
+const sliderRangeStyling = {
+  trackStyle: [
+    {
+      backgroundColor: "var(--color-primary)",
+      height: "5px",
+    },
+  ],
+  railStyle: {
+    backgroundColor: "var(--font-color2)",
+  },
+  handleStyle: [
+    {
+      backgroundColor: "white",
+      borderColor: "white",
+    },
+    {
+      backgroundColor: "white",
+      borderColor: "white",
+    },
+  ],
+};
 
 // Please check https://github.com/react-component/slider#user-content-common-api
 // for all available props.
@@ -35,15 +55,12 @@ const SliderRange = ({
   };
 
   return (
-    <StyledSliderRange>
+    <StyledSliderRange className={props.className}>
       <span>{`${minMaxValues[0]}`}</span>
       <Range
         {...props}
-        {...sliderStyling}
+        {...sliderRangeStyling}
         value={props.value.length ? props.value : [defaultMin, defaultMax]}
-        style={{
-          width: "20em",
-        }}
         onChange={onChangeCustom}
       />
       <span>{`${minMaxValues[1]}${

--- a/src/views/GameListView.jsx
+++ b/src/views/GameListView.jsx
@@ -294,6 +294,8 @@ const GameListView = () => {
               <span className="filter-title">{t("Number of players")}</span>
               <SliderRange
                 defaultValue={[1, 9]}
+                min={1}
+                max={9}
                 value={filterCriteria.nbOfPlayers}
                 step={1}
                 onChange={onChangeNbOfPlayersSlider}
@@ -302,7 +304,9 @@ const GameListView = () => {
             <li className="duration-filter">
               <span className="filter-title">{t("Duration (mins)")}</span>
               <SliderRange
-                defaultValue={[15, 90]}
+                defaultValue={[2, 4]}
+                min={15}
+                max={90}
                 value={filterCriteria.durations}
                 step={15}
                 onChange={onChangeDurationSlider}

--- a/src/views/GameListView.jsx
+++ b/src/views/GameListView.jsx
@@ -304,7 +304,7 @@ const GameListView = () => {
             <li className="duration-filter">
               <span className="filter-title">{t("Duration (mins)")}</span>
               <SliderRange
-                defaultValue={[2, 4]}
+                defaultValue={[15, 90]}
                 min={15}
                 max={90}
                 value={filterCriteria.durations}


### PR DESCRIPTION
### Slider

Before:

<img width="350" alt="Screen Shot 2021-04-24 at 16 12 05" src="https://user-images.githubusercontent.com/2834704/115963584-db7a7a80-a517-11eb-9a5d-e826cac051e3.png">

After:

<img width="352" alt="Screen Shot 2021-04-25 at 13 07 46" src="https://user-images.githubusercontent.com/2834704/115992782-60709d00-a5c7-11eb-902b-cc30076c1472.png">


### Slider Range

Before:

<img width="442" alt="Screen Shot 2021-04-24 at 14 17 47" src="https://user-images.githubusercontent.com/2834704/115962271-6c4e5780-a512-11eb-9b49-f3d8659b29a5.png">

After:

<img width="459" alt="Screen Shot 2021-04-24 at 15 33 47" src="https://user-images.githubusercontent.com/2834704/115962294-80925480-a512-11eb-9dbb-c3bdba23bf7e.png">

Related to #319 
